### PR TITLE
Added possibility to ignore JaRB validation constraints for a specific field

### DIFF
--- a/app/es6/jarb-formly-field-transformer.factory.js
+++ b/app/es6/jarb-formly-field-transformer.factory.js
@@ -86,10 +86,14 @@ angular.module('jarb-angular-formly')
      * @return {[field]}        A transformed array of formly fields
      */
     function transform(fields, model, options) {
+      if (entityNameIsDefined(options) === false) {
+        return fields;
+      }
+
       const constraints = constraintsStore.getConstraints();
 
       return fields.map((field) => {
-        if (entityNameIsDefined(options) === false) {
+        if (_.get(field, 'data.ignoreJarbConstraints') === true) {
           return field;
         }
 

--- a/app/es6/jarb-formly-field-transformer.factory.spec.js
+++ b/app/es6/jarb-formly-field-transformer.factory.spec.js
@@ -94,6 +94,21 @@ describe('Service: jarbFormlyFieldTransformer', function () {
           "min": null,
           "max": null,
           "name": "address.city"
+        },
+        "locallyIgnoredProperty": {
+          "javaType": "java.lang.String",
+          "types": [
+            "text"
+          ],
+          "required": false,
+          "minimumLength": null,
+          "maximumLength": 255,
+          "fractionLength": 0,
+          "radix": 10,
+          "pattern": null,
+          "min": null,
+          "max": null,
+          "name": "locallyIgnoredProperty"
         }
       }
     };
@@ -240,6 +255,25 @@ describe('Service: jarbFormlyFieldTransformer', function () {
           type: 'name',
           label: 'Superpower',
           placeholder: 'Please enter the super power of the hero'
+        }
+      }];
+
+      const expected = angular.copy(formlyFields);
+      expect(jarbFormlyFieldTransformer.transform(formlyFields, null, entityNameOptions)).toEqual(expected);
+    });
+
+    it('should not change the field when it is marked to be ignored', () => {
+      const formlyFields = [{
+        id: 'locallyIgnoredProperty',
+        key: 'locallyIgnoredProperty',
+        type: 'input',
+        data: {
+          ignoreJarbConstraints: true
+        },
+        templateOptions: {
+          type: 'name',
+          label: 'Locally ignored property',
+          placeholder: 'We do not want any JaRB validation for this field!'
         }
       }];
 


### PR DESCRIPTION
Added possibility to ignore JaRB validation
constraints for a specific field. Analogous
to JaRB's @IgnoreDatabaseConstraints annotation
for backend form fields the property is called
ignoreDatabaseConstraints and can be defined on
a field's data object.

Furthermore an optimization has been made by
placing the entityNameIsDefined check outside
of the loop since this affects the entire entity.